### PR TITLE
Vertically align lowercase character

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,6 +28,9 @@
         font-family: monospace serif sans-serif;
         font-size: 60vh;
         outline: none;
+
+        text-box-trim: trim-both;
+        text-box-edge: ex alphabetic;
       }
 
       #copied {


### PR DESCRIPTION
This only works for Chromium 133+ and Safari 18.2+, so it’s a progressive enhancement.

(Also, the `font-family` declaration a few lines up is invalid. Needs commas.)