### PR TITLE
Ensure character is visible on iOS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
       #the-button {
         background: none;
         border: none;
+        color: CanvasText;
 
         width: 100%;
         height: 100%;


### PR DESCRIPTION
iOS Safari has a UA style of `color: white` for buttons, so currently it’s white text on a white background.